### PR TITLE
chore(schedule): update default schedule and added noisy package rules

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,13 +11,19 @@
         ":pinAllExceptPeerDependencies"
     ],
     "schedule": [
-        "after 8am every weekday and before 6pm every weekday"
+        "after 3am every day and before 10pm every day"
     ],
     "major": {
         "labels": ["dependencies", "major"]
     },
     "minor": {
         "labels": ["dependencies", "minor"]
-    }
+    },
+    "packageRules": [
+        {
+            "packageNames": ["aws-sdk", "eslint"],
+            "extends": ["schedule:weekly"]
+        }
+    ]
 }
 


### PR DESCRIPTION
As I have been adding renovate to more of our repos, I have found our current schedule to be a bit limiting. If you add renovate on off hours, you will not get the benefits until the next business day. I propose that we open up the running time of renovate.

Also, packages like `aws-sdk` update very very often with minimal impact. I added a `weekly` run scope to `aws-sdk` and `eslint` to help with PR noise.

- Updated default `schedule` to be more broad, including weekends, in order to accommodate a broader range of working hours across time zones
- Added weekends to allowed schedule time for renovate
- Limited `aws-sdk` and `eslint` to running only once a week as these can be noisy with patch and minor updates. Especially `aws-sdk`