### PR TITLE
feat(renovate): add extension for group:allNonMajor

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,8 @@
     },
     "extends": [
         "config:base",
-        ":pinAllExceptPeerDependencies"
+        ":pinAllExceptPeerDependencies",
+        "group:allNonMajor"
     ],
     "schedule": [
         "after 3am every day and before 10pm every day"


### PR DESCRIPTION
This change enables the [`group:allNonMajor`](https://docs.renovatebot.com/presets-group/#groupallnonmajor) feature within renovate. This will roll up all non-major changes into a single PR, rather than N PRs, one for each patch.

I like this feature as it will reduce noise from renovate and provide a convenient way group many changes in one.

Examples: 
Go project: https://github.com/GoodwayGroup/gw-aws-audit/pull/40
Node project: https://github.com/GoodwayGroup/lib-hapi-rollbar/pull/65
