### PR TITLE
chore(schedule): adjust schedule for noisy dotenv deps

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,6 +29,10 @@
             "extends": ["schedule:weekly"]
         },
         {
+            "packageNames": ["dotenv", "dotenv-cli", "cross-env"],
+            "extends": ["schedule:monthly"]
+        },
+        {
             "packagePatterns": [ "^@goodwaygroup/" ],
             "groupName": "@goodwaygroup monorepo"
         }


### PR DESCRIPTION
Adjusted the check schedule for `dotenv`, `dotenv-cli` and `cross-env`. These have become noisy the past few months and they are primarily small patch changes. The schedule adjustment moves checks for major and minor changes to monthly. This does not affect security patches.